### PR TITLE
RFC: Support react hooks

### DIFF
--- a/extraParams.hxml
+++ b/extraParams.hxml
@@ -1,2 +1,3 @@
+--macro coconut.react.macros.Setup.sugar()
 --macro coconut.react.macros.Setup.all()
 -D hxx_fragment=coconut.ui.ViewBase.createFragment

--- a/src/coconut/react/macros/Setup.hx
+++ b/src/coconut/react/macros/Setup.hx
@@ -182,15 +182,21 @@ class Setup {
               function(hook, last:Array<Expr>) return last.concat(hook.params), 
               []
             );
-            if(exprs.length > 0)
-              trace('transforming ${c.target.name}::${member.name}');
-              f.expr = macro {
-                function Render() {
+            
+            
+            if(exprs.length > 0) {
+              var name = 'HookWrapper_${member.name}';
+              var jsx = '<$name/>';
+              var expr = f.expr;
+              f.expr = macro return react.ReactMacro.jsx($v{jsx});
+              c.addMembers(macro class {
+                function $name() {
                   @:mergeBlock $b{exprs};
-                  ${f.expr};
+                  ${expr};
                 }
-                return react.ReactMacro.jsx('<Render/>');
-              }
+              });
+            }
+              
           case _:
         }
       }


### PR DESCRIPTION
Not sure how sensible this is, feel free to comment.

In react world, hooks only works on function component but not classy ones. So in order to use them in coconut views I added a new meta `@:coconut.react.hook(expr)`, which will create a function wrapper where hooks can be used and transform the original renderer to render that function component.

```haxe
@:coconut.react.hook(var theme = useTheme())
function render() '<div/>'
```

will become:

```haxe
function render() return jsx('<HookWrapper_render/>');

function HookWrapper_render() {
  var theme = useTheme()
  return hxx('<div/>');
}
```