### PR TITLE
Initial attempt to HOC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        haxe-version:
+          - stable
+          - nightly
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: lix-pm/setup-lix@master
+    - run: lix install haxe ${{ matrix.haxe-version }}
+    - run: lix download
+    - run: lix run travix js

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
 
 jobs:
   include:
-    - stage: test # should uncomment this when there is no matrix above (e.g. only one os, one env, etc)
+    # - stage: test # should uncomment this when there is no matrix above (e.g. only one os, one env, etc)
     - stage: deploy
       os: linux
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ os:
   # - osx
 
 env:
-  - HAXE_VERSION=3.4.7
+  - HAXE_VERSION=stable
   - HAXE_VERSION=latest
-  # - HAXE_VERSION=nightly
+  - HAXE_VERSION=nightly
   
 install:
   - npm i -g lix

--- a/haxe_libraries/ansi.hxml
+++ b/haxe_libraries/ansi.hxml
@@ -1,0 +1,3 @@
+# @install: lix --silent download haxelib:ansi#1.0.0 into ansi/1.0.0/haxelib
+-D ansi=1.0.0
+-cp ${HAXESHIM_LIBCACHE}/ansi/1.0.0/haxelib/src

--- a/haxe_libraries/coconut.data.hxml
+++ b/haxe_libraries/coconut.data.hxml
@@ -1,7 +1,8 @@
--D coconut.data=0.9.0
-# @install: lix --silent download "haxelib:/coconut.data#0.9.0" into coconut.data/0.9.0/haxelib
+-D coconut.data=0.10.0
+# @install: lix --silent download "gh://github.com/MVCoconut/coconut.data#454b73c257036145f8567cb939f6d42fac6b3d29" into coconut.data/0.10.0/github/454b73c257036145f8567cb939f6d42fac6b3d29
 -lib tink_anon
 -lib tink_lang
 -lib tink_pure
 -lib tink_state
--cp ${HAXE_LIBCACHE}/coconut.data/0.9.0/haxelib/src
+-cp ${HAXE_LIBCACHE}/coconut.data/0.10.0/github/454b73c257036145f8567cb939f6d42fac6b3d29/src
+--macro coconut.data.macros.Setup.run()

--- a/haxe_libraries/coconut.react-dom.hxml
+++ b/haxe_libraries/coconut.react-dom.hxml
@@ -1,0 +1,6 @@
+-D coconut.react-dom=0.1.0
+# @install: lix --silent download "gh://github.com/MVCoconut/coconut.react-dom#eb72b2561383068a86757d1466b491a0ae1f5d75" into coconut.react-dom/0.1.0/github/eb72b2561383068a86757d1466b491a0ae1f5d75
+-lib coconut.react-core
+-lib xDOM
+-cp ${HAXE_LIBCACHE}/coconut.react-dom/0.1.0/github/eb72b2561383068a86757d1466b491a0ae1f5d75/src
+--macro coconut.react.macros.Html.registerTags()

--- a/haxe_libraries/coconut.ui.hxml
+++ b/haxe_libraries/coconut.ui.hxml
@@ -1,8 +1,8 @@
 -D coconut.ui=0.10.0
-# @install: lix --silent download "haxelib:/coconut.ui#0.10.0" into coconut.ui/0.10.0/haxelib
+# @install: lix --silent download "gh://github.com/MVCoconut/coconut.ui#4421d913ef599d68bfa3f74653272f1502dbb798" into coconut.ui/0.10.0/github/4421d913ef599d68bfa3f74653272f1502dbb798
 -lib coconut.data
 -lib tink_anon
 -lib tink_hxx
 -lib tink_lang
--cp ${HAXE_LIBCACHE}/coconut.ui/0.10.0/haxelib/src
+-cp ${HAXE_LIBCACHE}/coconut.ui/0.10.0/github/4421d913ef599d68bfa3f74653272f1502dbb798/src
 -D coconut_ui

--- a/haxe_libraries/react-next.hxml
+++ b/haxe_libraries/react-next.hxml
@@ -1,9 +1,9 @@
--D react-next=1.117.0
-# @install: lix --silent download "haxelib:/react-next#1.117.0" into react-next/1.117.0/haxelib
+-D react-next=1.120.0
+# @install: lix --silent download "haxelib:/react-next#1.120.0" into react-next/1.120.0/haxelib
 -lib js-object
 -lib tink_hxx
--cp ${HAXE_LIBCACHE}/react-next/1.117.0/haxelib/src/lib
+-cp ${HAXE_LIBCACHE}/react-next/1.120.0/haxelib/src/lib
 --macro react.jsx.JsxStaticMacro.addHook()
 --macro addGlobalMetadata('', '@:build(react.jsx.JsxStaticMacro.build())')
 
--D react=1.117.0
+-D react=1.120.0

--- a/haxe_libraries/tink_anon.hxml
+++ b/haxe_libraries/tink_anon.hxml
@@ -1,4 +1,4 @@
--D tink_anon=0.4.1
-# @install: lix --silent download "haxelib:/tink_anon#0.4.1" into tink_anon/0.4.1/haxelib
+-D tink_anon=0.5.0
+# @install: lix --silent download "haxelib:/tink_anon#0.5.0" into tink_anon/0.5.0/haxelib
 -lib tink_macro
--cp ${HAXE_LIBCACHE}/tink_anon/0.4.1/haxelib/src
+-cp ${HAXE_LIBCACHE}/tink_anon/0.5.0/haxelib/src

--- a/haxe_libraries/tink_core.hxml
+++ b/haxe_libraries/tink_core.hxml
@@ -1,3 +1,3 @@
--D tink_core=1.24.0
-# @install: lix --silent download "haxelib:/tink_core#1.24.0" into tink_core/1.24.0/haxelib
--cp ${HAXE_LIBCACHE}/tink_core/1.24.0/haxelib/src
+-D tink_core=1.25.0
+# @install: lix --silent download "haxelib:/tink_core#1.25.0" into tink_core/1.25.0/haxelib
+-cp ${HAXE_LIBCACHE}/tink_core/1.25.0/haxelib/src

--- a/haxe_libraries/tink_csss.hxml
+++ b/haxe_libraries/tink_csss.hxml
@@ -1,3 +1,4 @@
-# @install: lix download https://github.com/haxetink/tink_csss/archive/0bb0e2ea5f8e6cec691ec26a257bccee549c6fca.tar.gz as tink_csss#0.0.0-alpha.0/0bb0e2ea5f8e6cec691ec26a257bccee549c6fca
--D tink_csss=0.0.0-alpha.0
--cp ${HAXESHIM_LIBCACHE}/tink_csss/0.0.0-alpha.0/0bb0e2ea5f8e6cec691ec26a257bccee549c6fca/src
+-D tink_csss=0.2.2
+# @install: lix --silent download "gh://github.com/haxetink/tink_csss#ada0a69031dfe4474d963cc5ba719de5f4264e58" into tink_csss/0.2.2/github/ada0a69031dfe4474d963cc5ba719de5f4264e58
+-lib tink_parse
+-cp ${HAXE_LIBCACHE}/tink_csss/0.2.2/github/ada0a69031dfe4474d963cc5ba719de5f4264e58/src

--- a/haxe_libraries/tink_domspec.hxml
+++ b/haxe_libraries/tink_domspec.hxml
@@ -1,4 +1,5 @@
--D tink_domspec=0.1.2
-# @install: lix --silent download "gh://github.com/haxetink/tink_domspec#86f77bdf22f109f30178447678a120bc318a386c" into tink_domspec/0.1.2/github/86f77bdf22f109f30178447678a120bc318a386c
+-D tink_domspec=0.2.0
+# @install: lix --silent download "gh://github.com/haxetink/tink_domspec#73e13f0752c9f15039663721f01bd73b4c2ec035" into tink_domspec/0.2.0/github/73e13f0752c9f15039663721f01bd73b4c2ec035
 -lib tink_macro
--cp ${HAXE_LIBCACHE}/tink_domspec/0.1.2/github/86f77bdf22f109f30178447678a120bc318a386c/src
+-lib tink_svgspec
+-cp ${HAXE_LIBCACHE}/tink_domspec/0.2.0/github/73e13f0752c9f15039663721f01bd73b4c2ec035/src

--- a/haxe_libraries/tink_hxx.hxml
+++ b/haxe_libraries/tink_hxx.hxml
@@ -1,6 +1,6 @@
--D tink_hxx=0.22.2
-# @install: lix --silent download "haxelib:/tink_hxx#0.22.2" into tink_hxx/0.22.2/haxelib
+-D tink_hxx=0.23.0
+# @install: lix --silent download "haxelib:/tink_hxx#0.23.0" into tink_hxx/0.23.0/haxelib
 -lib html-entities
 -lib tink_anon
 -lib tink_parse
--cp ${HAXE_LIBCACHE}/tink_hxx/0.22.2/haxelib/src
+-cp ${HAXE_LIBCACHE}/tink_hxx/0.23.0/haxelib/src

--- a/haxe_libraries/tink_macro.hxml
+++ b/haxe_libraries/tink_macro.hxml
@@ -1,4 +1,4 @@
--D tink_macro=0.18.0
-# @install: lix --silent download "haxelib:/tink_macro#0.18.0" into tink_macro/0.18.0/haxelib
+-D tink_macro=0.19.0
+# @install: lix --silent download "haxelib:/tink_macro#0.19.0" into tink_macro/0.19.0/haxelib
 -lib tink_core
--cp ${HAXE_LIBCACHE}/tink_macro/0.18.0/haxelib/src
+-cp ${HAXE_LIBCACHE}/tink_macro/0.19.0/haxelib/src

--- a/haxe_libraries/tink_priority.hxml
+++ b/haxe_libraries/tink_priority.hxml
@@ -1,3 +1,3 @@
--D tink_priority=0.1.4
-# @install: lix --silent download "haxelib:/tink_priority#0.1.4" into tink_priority/0.1.4/haxelib
--cp ${HAXE_LIBCACHE}/tink_priority/0.1.4/haxelib/src
+# @install: lix --silent download haxelib:tink_priority#0.1.3 into tink_priority/0.1.3/haxelib
+-D tink_priority=0.1.3
+-cp ${HAXESHIM_LIBCACHE}/tink_priority/0.1.3/haxelib/src

--- a/haxe_libraries/tink_state.hxml
+++ b/haxe_libraries/tink_state.hxml
@@ -1,4 +1,4 @@
--D tink_state=0.10.1
-# @install: lix --silent download "haxelib:/tink_state#0.10.1" into tink_state/0.10.1/haxelib
+-D tink_state=0.11.0
+# @install: lix --silent download "gh://github.com/haxetink/tink_state#c0074b8afd24dda077967ebc09fa8281bac41035" into tink_state/0.11.0/github/c0074b8afd24dda077967ebc09fa8281bac41035
 -lib tink_core
--cp ${HAXE_LIBCACHE}/tink_state/0.10.1/haxelib/src
+-cp ${HAXE_LIBCACHE}/tink_state/0.11.0/github/c0074b8afd24dda077967ebc09fa8281bac41035/src

--- a/haxe_libraries/tink_streams.hxml
+++ b/haxe_libraries/tink_streams.hxml
@@ -1,6 +1,6 @@
-# @install: lix --silent download "https://github.com/haxetink/tink_streams/archive/a38e3a97e8512830b31f1fe9476a752cf6fb51ff.tar.gz" into tink_streams/0.2.1/github/a38e3a97e8512830b31f1fe9476a752cf6fb51ff
--D tink_streams=0.2.1
--cp ${HAXESHIM_LIBCACHE}/tink_streams/0.2.1/github/a38e3a97e8512830b31f1fe9476a752cf6fb51ff/src
+-D tink_streams=0.3.2
+# @install: lix --silent download "gh://github.com/haxetink/tink_streams#1c3fa5e1235fff5231fe89535e5f3eff6b654822" into tink_streams/0.3.2/github/1c3fa5e1235fff5231fe89535e5f3eff6b654822
+-lib tink_core
+-cp ${HAXE_LIBCACHE}/tink_streams/0.3.2/github/1c3fa5e1235fff5231fe89535e5f3eff6b654822/src
 # temp for development, delete this file when pure branch merged
 -D pure
--lib tink_core

--- a/haxe_libraries/tink_svgspec.hxml
+++ b/haxe_libraries/tink_svgspec.hxml
@@ -1,0 +1,3 @@
+-D tink_svgspec=0.0.1
+# @install: lix --silent download "gh://github.com/haxetink/tink_svgspec#85ae7591c595848b8de2d55b628db766339b0c6b" into tink_svgspec/0.0.1/github/85ae7591c595848b8de2d55b628db766339b0c6b
+-cp ${HAXE_LIBCACHE}/tink_svgspec/0.0.1/github/85ae7591c595848b8de2d55b628db766339b0c6b/src

--- a/haxe_libraries/tink_syntaxhub.hxml
+++ b/haxe_libraries/tink_syntaxhub.hxml
@@ -1,6 +1,6 @@
--D tink_syntaxhub=0.4.3
-# @install: lix --silent download "haxelib:/tink_syntaxhub#0.4.3" into tink_syntaxhub/0.4.3/haxelib
--lib tink_macro
--lib tink_priority
--cp ${HAXE_LIBCACHE}/tink_syntaxhub/0.4.3/haxelib/src
+# @install: lix --silent download https://github.com/haxetink/tink_syntaxhub/archive/b8a7e51a48c002cbeedb873f6cec177dbec9b8fd.tar.gz into tink_syntaxhub/0.3.6/github/b8a7e51a48c002cbeedb873f6cec177dbec9b8fd
+-D tink_syntaxhub=0.3.6
+-cp ${HAXESHIM_LIBCACHE}/tink_syntaxhub/0.3.6/github/b8a7e51a48c002cbeedb873f6cec177dbec9b8fd/src
 --macro tink.SyntaxHub.use()
+-lib tink_priority
+-lib tink_macro

--- a/haxe_libraries/tink_testrunner.hxml
+++ b/haxe_libraries/tink_testrunner.hxml
@@ -1,0 +1,6 @@
+-D tink_testrunner=0.7.1
+# @install: lix --silent download "gh://github.com/haxetink/tink_testrunner#1928e3a72a4ae2d69b3a38350a6e1bdd89bdead9" into tink_testrunner/0.7.1/github/1928e3a72a4ae2d69b3a38350a6e1bdd89bdead9
+-lib ansi
+-lib tink_macro
+-lib tink_streams
+-cp ${HAXE_LIBCACHE}/tink_testrunner/0.7.1/github/1928e3a72a4ae2d69b3a38350a6e1bdd89bdead9/src

--- a/haxe_libraries/tink_unittest.hxml
+++ b/haxe_libraries/tink_unittest.hxml
@@ -1,0 +1,6 @@
+-D tink_unittest=0.6.2
+# @install: lix --silent download "gh://github.com/haxetink/tink_unittest#6a242452deeb34fd42a6fa865b11d42d3cba551d" into tink_unittest/0.6.2/github/6a242452deeb34fd42a6fa865b11d42d3cba551d
+-lib tink_syntaxhub
+-lib tink_testrunner
+-cp ${HAXE_LIBCACHE}/tink_unittest/0.6.2/github/6a242452deeb34fd42a6fa865b11d42d3cba551d/src
+--macro tink.unit.AssertionBufferInjector.use()

--- a/haxe_libraries/xDOM.hxml
+++ b/haxe_libraries/xDOM.hxml
@@ -1,5 +1,5 @@
--D xDOM=0.1.0
-# @install: lix --silent download "haxelib:/xDOM#0.1.0" into xDOM/0.1.0/haxelib
+-D xDOM=0.2.1
+# @install: lix --silent download "gh://github.com/back2dos/xDOM#739e6ece8bcd6f965b9dd45183ce0eb8a60002d8" into xDOM/0.2.1/github/739e6ece8bcd6f965b9dd45183ce0eb8a60002d8
+-lib tink_csss
 -lib tink_domspec
--lib tink_macro
--cp ${HAXE_LIBCACHE}/xDOM/0.1.0/haxelib/src
+-cp ${HAXE_LIBCACHE}/xDOM/0.2.1/github/739e6ece8bcd6f965b9dd45183ce0eb8a60002d8/src

--- a/src/coconut/react/macros/Setup.hx
+++ b/src/coconut/react/macros/Setup.hx
@@ -238,10 +238,11 @@ class Setup {
             
             init.expr = init.expr.concat(macro {
               var value:Dynamic = (cast $i{init.args[0].name}).$name;
-              if(Std.is(value, tink.state.Observable.ObservableObject)) {
-                if($i{internal} != value) $i{internal} = value; // TODO: this is so hacky, fix me please
-              } else {
-                (cast $i{internal}:tink.state.State<$ct>).set(value);
+              if(($i{internal}:Dynamic) != value) {
+                if(Std.is(value, tink.state.Observable.ObservableObject))
+                  $i{internal} = value; // TODO: this is so hacky, fix me please
+                else
+                  (cast $i{internal}:tink.state.State<$ct>).set(value);
               }
             });
             

--- a/src/coconut/react/macros/Setup.hx
+++ b/src/coconut/react/macros/Setup.hx
@@ -167,11 +167,11 @@ class Setup {
             false;
           case wraps:
             var wrapped = macro cast $i{ctx.target.target.name};
-          
-            for(wrap in wraps) {
-              switch wrap.params {
-                case [wrapper]: wrapped = macro $wrapper($wrapped);
-                case _: wrap.pos.error('@:wrap requires exactly one parameter');
+            
+            for(i in 0...wraps.length) { // loop in reverse, so that the first meta will become the outermost wrap
+              switch wraps[wraps.length - i - 1] {
+                case {params: [wrapper]}: wrapped = macro $wrapper($wrapped);
+                case wrap: wrap.pos.error('@:wrap requires exactly one parameter');
               }
             }
             

--- a/src/coconut/react/macros/Setup.hx
+++ b/src/coconut/react/macros/Setup.hx
@@ -127,14 +127,13 @@ class Setup {
 
       var self = toComplex(cls);
 
-      var extendTypes = [];
       var attributeFields = ctx.attributes.concat(
         (macro class {
           @:optional var key(default, never):coconut.react.Key;
           @:optional var ref(default, never):coconut.ui.Ref<$self>;
         }).fields
       );
-      var attributes = TExtend(extendTypes, attributeFields);
+      var attributes = TAnonymous(attributeFields);
 
       {
         var render = ctx.target.memberByName('render').sure();
@@ -177,16 +176,14 @@ class Setup {
                 wrapped = macro $wrapper($wrapped);
               case {params: [wrapper, e = macro (_:$ct)]}: // https://github.com/HaxeFoundation/haxe-evolution/pull/44
                 switch ct.toType() {
-                  case Success(_.toComplex() => TAnonymous(fields)):
+                  case Success(_.reduce().toComplex() => TAnonymous(fields)):
                     for(field in fields) attributeFields.push(field);
-                  case Success(t = _.toComplex() => TPath(path)) if(t.reduce().match(TAnonymous(_))):
-                    extendTypes.push(path);
                   case _:
                     e.pos.error('Expected anonymous structure type');
                 }
                 wrapped = macro $wrapper($wrapped);
               case {params: [wrapper, _], pos: pos}:
-                pos.error('Second parameter of @:wrap should be a ECheckType expr');
+                pos.error('Second parameter of @:wrap should be a ETypeCheck expr');
               case {pos: pos}:
                 pos.error('@:wrap must have one or two parameters');
             }

--- a/src/coconut/react/macros/Setup.hx
+++ b/src/coconut/react/macros/Setup.hx
@@ -183,9 +183,9 @@ class Setup {
                 }
                 wrapped = macro $wrapper($wrapped);
               case {params: [wrapper, _], pos: pos}:
-                pos.error('Second parameter of @:wrap should be a ETypeCheck expr of an anonymous structure');
+                pos.error('Second parameter of @:wrap should be a ETypeCheck expr');
               case {pos: pos}:
-                pos.error('@:wrap must has one or two parameters');
+                pos.error('@:wrap must have one or two parameters');
             }
           }
           
@@ -199,24 +199,27 @@ class Setup {
       // injected props
       for(member in ctx.target)
         switch [member.kind, member.meta.filter(function(meta) return meta.name == ':react.injected')] {
-          case [_, []]: // skip
-          case [FFun(_), _]: member.pos.error('@:react.injected does not work on functions');
+          case [_, []]:
+            // skip
+          case [FFun(_), _]:
+            member.pos.error('@:react.injected does not work on functions');
           case [FVar(ct, e) | FProp(_, _, ct, e), [meta = {params: params}]]:
-            if(e != null) e.pos.error('Field with @:react.injected cannot have a initializer');
+            if(e != null) e.pos.error('Field with @:react.injected cannot have an initializer');
             var name = switch params {
               case []:
                 member.name;
               case [macro $v{(name:String)}]:
                 name;
               case _:
-                meta.pos.error('@:react.injected should have exactly one parameter');
+                meta.pos.error('@:react.injected should have at most one parameter');
             }
             member.kind = FProp('get', 'never', ct, null);
             var getter = member.name.getter(macro return (cast props).$name);
             getter.isBound = true;
             ctx.target.addMember(getter);
             
-          case _: member.pos.error('Multiple @:react.injected is not supported');
+          case _:
+            member.pos.error('Multiple @:react.injected is not supported');
         }
       
       var added = ctx.target.addMembers(macro class {

--- a/src/coconut/react/macros/Setup.hx
+++ b/src/coconut/react/macros/Setup.hx
@@ -160,32 +160,27 @@ class Setup {
       ctx.target.getConstructor().addStatement(macro this.__stateMap = $stateMap);
       #end
       
-      var wrapped =
-        switch cls.meta.extract(':react.hoc') {
-          case []:
-            // do nothing
-            false;
-          case wraps:
-            var wrapped = macro cast $i{ctx.target.target.name};
-            
-            for(i in 0...wraps.length) { // loop in reverse, so that the first meta will become the outermost wrap
-              switch wraps[wraps.length - i - 1] {
-                case {params: [wrapper]}: wrapped = macro $wrapper($wrapped);
-                case wrap: wrap.pos.error('@:wrap requires exactly one parameter');
-              }
-            }
-            
-            ctx.target.addMembers(macro class {
-              @:keep static var __hoc:react.ReactType = $wrapped;
-            });
-            
-            wrapped.log();
-            
-            true;
-        }
-      
       var reactType = macro cast $i{ctx.target.target.name};
-      if(wrapped) reactType = macro $reactType.__hoc;
+      
+      switch cls.meta.extract(':react.hoc') {
+        case []:
+          // do nothing
+        case wraps:
+          var wrapped = macro cast $i{ctx.target.target.name};
+          
+          for(i in 0...wraps.length) { // loop in reverse, so that the first meta will become the outermost wrap
+            switch wraps[wraps.length - i - 1] {
+              case {params: [wrapper]}: wrapped = macro $wrapper($wrapped);
+              case wrap: wrap.pos.error('@:wrap requires exactly one parameter');
+            }
+          }
+          
+          ctx.target.addMembers(macro class {
+            @:keep static var __hoc:react.ReactType = $wrapped;
+          });
+          
+          reactType = macro $reactType.__hoc;
+      }
       
       var added = ctx.target.addMembers(macro class {
         #if react_devtools

--- a/src/coconut/react/macros/Setup.hx
+++ b/src/coconut/react/macros/Setup.hx
@@ -127,13 +127,14 @@ class Setup {
 
       var self = toComplex(cls);
 
+      var extendTypes = [];
       var attributeFields = ctx.attributes.concat(
         (macro class {
           @:optional var key(default, never):coconut.react.Key;
           @:optional var ref(default, never):coconut.ui.Ref<$self>;
         }).fields
       );
-      var attributes = TAnonymous(attributeFields);
+      var attributes = TExtend(extendTypes, attributeFields);
 
       {
         var render = ctx.target.memberByName('render').sure();
@@ -176,14 +177,16 @@ class Setup {
                 wrapped = macro $wrapper($wrapped);
               case {params: [wrapper, e = macro (_:$ct)]}: // https://github.com/HaxeFoundation/haxe-evolution/pull/44
                 switch ct.toType() {
-                  case Success(_.reduce().toComplex() => TAnonymous(fields)):
+                  case Success(_.toComplex() => TAnonymous(fields)):
                     for(field in fields) attributeFields.push(field);
+                  case Success(t = _.toComplex() => TPath(path)) if(t.reduce().match(TAnonymous(_))):
+                    extendTypes.push(path);
                   case _:
                     e.pos.error('Expected anonymous structure type');
                 }
                 wrapped = macro $wrapper($wrapped);
               case {params: [wrapper, _], pos: pos}:
-                pos.error('Second parameter of @:wrap should be a ETypeCheck expr');
+                pos.error('Second parameter of @:wrap should be a ECheckType expr');
               case {pos: pos}:
                 pos.error('@:wrap must have one or two parameters');
             }

--- a/src/coconut/react/macros/Setup.hx
+++ b/src/coconut/react/macros/Setup.hx
@@ -174,7 +174,7 @@ class Setup {
             switch wraps[wraps.length - i - 1] {
               case {params: [wrapper]}:
                 wrapped = macro $wrapper($wrapped);
-              case {params: [wrapper, e = macro (_:$ct)]}:
+              case {params: [wrapper, e = macro (_:$ct)]}: // https://github.com/HaxeFoundation/haxe-evolution/pull/44
                 switch ct.toType() {
                   case Success(_.reduce().toComplex() => TAnonymous(fields)):
                     for(field in fields) attributeFields.push(field);

--- a/tests.hxml
+++ b/tests.hxml
@@ -2,6 +2,11 @@
 -main RunTests
 -dce full
 
+
 -D react_global
 -lib embed-js
 --macro embed.Js.from('http://cdnjs.cloudflare.com/ajax/libs/react/16.10.2/umd/react.production.min.js')
+--macro embed.Js.from('http://cdnjs.cloudflare.com/ajax/libs/react-dom/16.13.0/umd/react-dom.production.min.js')
+
+-lib tink_unittest
+-lib coconut.react-dom

--- a/tests/HocTest.hx
+++ b/tests/HocTest.hx
@@ -35,7 +35,7 @@ class HocTest {
 }
 
 @:react.hoc(wrapper)
-class Wrapped extends coconut.ui.View {
+private class Wrapped extends coconut.ui.View {
 	@:attr var onUpdate:(foo:Int)->Void;
 	@:attr var onFinish:()->Void;
 	
@@ -54,7 +54,8 @@ class Wrapped extends coconut.ui.View {
 	}
 }
 
-class Injector extends ReactComponent {
+// TODO: marking this as non-private works on 4.0.5 but not nightly
+private class Injector extends ReactComponent {
 	final timer:Timer;
 	
 	public function new(props) {

--- a/tests/HocTest.hx
+++ b/tests/HocTest.hx
@@ -1,0 +1,72 @@
+package;
+
+import haxe.Timer;
+import react.React;
+import js.Browser.*;
+import coconut.Ui.hxx;
+import react.ReactType;
+import react.ReactComponent;
+
+using coconut.ui.Renderer;
+
+@:asserts
+class HocTest {
+	public function new() {}
+	
+	public function test() {
+		var div = document.createDivElement();
+		document.body.appendChild(div);
+		
+		var expected = 0;
+		
+		function done() {
+			document.body.removeChild(div);
+			asserts.done();
+		}
+		
+		function update(foo:Int) {
+			asserts.assert(foo == expected++);
+		}
+		
+		Renderer.mount(div, hxx('<Wrapped onUpdate=${update} onFinish=${done}/>'));
+		
+		return asserts;
+	}
+}
+
+@:react.hoc(wrapper)
+class Wrapped extends coconut.ui.View {
+	@:attr var onUpdate:(foo:Int)->Void;
+	@:attr var onFinish:()->Void;
+	
+	@:react.injected var foo:Int;
+	
+	static function wrapper(component:ReactType):ReactType {
+		return function(props)
+			return React.createElement(Injector, js.Object.assign({component: component}, props));
+	}
+	
+	function render() '<div>$foo</div>';
+	
+	function viewDidRender() {
+		onUpdate(foo);
+		if(foo == 5) onFinish();
+	}
+}
+
+class Injector extends ReactComponent {
+	final timer:Timer;
+	
+	public function new(props) {
+		super(props);
+		state = {foo: 0}
+		timer = new Timer(123);
+		timer.run = function() setState({foo: state.foo + 1});
+	}
+	override function render() {
+		return React.createElement(cast props.component, js.Object.assign({foo: state.foo}, props));
+	}
+	override function componentWillUnmount() {
+		timer.stop();
+	}
+}

--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -1,12 +1,15 @@
 package ;
 
 import coconut.ui.*;
+import tink.testrunner.*;
+import tink.unit.*;
 
 class RunTests {
 
   static function main() {
-    travix.Logger.println('it works');
-    travix.Logger.exit(0); // make sure we exit properly, which is necessary on some targets, e.g. flash & (phantom)js
+    Runner.run(TestBatch.make([
+      new HocTest(),
+    ])).handle(Runner.exit);
   }
   
 }


### PR DESCRIPTION
This generates a `static var __hoc:ReactType;` field and make `fromHxx` use it, if there is `@:react.hoc(wrapper)` meta.

~~Doesn't handle mutation of public prop list yet. Propose to add meta alongside `@:attr` (e.g. `@:internal`) to hide them. And add a second param to `@:react.hoc` to add extra props.~~